### PR TITLE
Fix: merge persistent rules from config and plugin

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         php: [ 8.5, 8.4, 8.3, 8.2 ]
         laravel: [ 13.*, 12.*, 11.* ]
+        filament: [ 5.* ]
         dependency-version: [ prefer-stable ]
         include:
           - laravel: 13.*
@@ -44,12 +45,37 @@ jobs:
           - php: 8.2
             pest: ^3.7
             pest-plugin-laravel: ^3.0
+          # Targeted Filament v4 coverage (v5 is covered by the matrix above).
+          # Filament 4 and 5 support the same Laravel/PHP range, so one job per
+          # Laravel line is enough without doubling the matrix. Standalone include
+          # jobs don't inherit other includes, so pest deps are set explicitly.
+          - php: 8.4
+            laravel: 13.*
+            testbench: 11.*
+            filament: 4.*
+            pest: ^4.0
+            pest-plugin-laravel: ^4.0
+            dependency-version: prefer-stable
+          - php: 8.4
+            laravel: 12.*
+            testbench: 10.*
+            filament: 4.*
+            pest: ^4.0
+            pest-plugin-laravel: ^4.0
+            dependency-version: prefer-stable
+          - php: 8.3
+            laravel: 11.*
+            testbench: 9.*
+            filament: 4.*
+            pest: ^4.0
+            pest-plugin-laravel: ^4.0
+            dependency-version: prefer-stable
         exclude:
           - laravel: 13.*
             php: 8.2
           - laravel: 11.*
             php: 8.5
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.dependency-version }}
     steps:
       - uses: actions/checkout@v6
 
@@ -80,7 +106,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer config policy.advisories.block false
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest-plugin-laravel }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:${{ matrix.filament }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest-plugin-laravel }}" --no-interaction --no-update
           if [ "${{ matrix.php }}" = "8.2" ]; then composer remove pestphp/pest-plugin-browser --dev --no-interaction --no-update; fi
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.5, 8.4, 8.3 ]
-        laravel: [ 13.*, 12.*, 11.* ]
+        laravel: [ 13.*, 12.* ]
         filament: [ 5.* ]
         dependency-version: [ prefer-stable ]
         include:
@@ -31,8 +31,6 @@ jobs:
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
           - php: 8.5
             pest: ^4.0
             pest-plugin-laravel: ^4.0
@@ -54,23 +52,13 @@ jobs:
             pest: ^4.0
             pest-plugin-laravel: ^4.0
             dependency-version: prefer-stable
-          - php: 8.3
+          - php: 8.2
             laravel: 12.*
             testbench: 10.*
-            filament: 4.*
-            pest: ^4.0
-            pest-plugin-laravel: ^4.0
-            dependency-version: prefer-stable
-          - php: 8.2
-            laravel: 11.*
-            testbench: 9.*
             filament: 4.*
             pest: ^3.7
             pest-plugin-laravel: ^3.0
             dependency-version: prefer-stable
-        exclude:
-          - laravel: 11.*
-            php: 8.5
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.dependency-version }}
     steps:
       - uses: actions/checkout@v6
@@ -101,7 +89,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer config policy.advisories.block false
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:${{ matrix.filament }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest-plugin-laravel }}" --no-interaction --no-update
           if [ "${{ matrix.php }}" = "8.2" ]; then composer remove pestphp/pest-plugin-browser --dev --no-interaction --no-update; fi
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.5, 8.4, 8.3, 8.2 ]
+        php: [ 8.5, 8.4, 8.3 ]
         laravel: [ 13.*, 12.*, 11.* ]
         filament: [ 5.* ]
         dependency-version: [ prefer-stable ]
@@ -42,13 +42,11 @@ jobs:
           - php: 8.3
             pest: ^4.0
             pest-plugin-laravel: ^4.0
-          - php: 8.2
-            pest: ^3.7
-            pest-plugin-laravel: ^3.0
-          # Targeted Filament v4 coverage (v5 is covered by the matrix above).
-          # Filament 4 and 5 support the same Laravel/PHP range, so one job per
-          # Laravel line is enough without doubling the matrix. Standalone include
-          # jobs don't inherit other includes, so pest deps are set explicitly.
+          # Filament 4 coverage (the matrix above covers v5). Filament 5 needs
+          # PHP 8.3+ via Livewire 4, so PHP 8.2 is only exercised against v4.
+          # One v4 job per Laravel line keeps coverage without doubling the
+          # matrix. Standalone include jobs don't inherit other includes, so
+          # testbench/pest deps are set explicitly.
           - php: 8.4
             laravel: 13.*
             testbench: 11.*
@@ -56,23 +54,21 @@ jobs:
             pest: ^4.0
             pest-plugin-laravel: ^4.0
             dependency-version: prefer-stable
-          - php: 8.4
+          - php: 8.3
             laravel: 12.*
             testbench: 10.*
             filament: 4.*
             pest: ^4.0
             pest-plugin-laravel: ^4.0
             dependency-version: prefer-stable
-          - php: 8.3
+          - php: 8.2
             laravel: 11.*
             testbench: 9.*
             filament: 4.*
-            pest: ^4.0
-            pest-plugin-laravel: ^4.0
+            pest: ^3.7
+            pest-plugin-laravel: ^3.0
             dependency-version: prefer-stable
         exclude:
-          - laravel: 13.*
-            php: 8.2
           - laravel: 11.*
             php: 8.5
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          composer config policy.advisories.block false
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest-plugin-laravel }}" --no-interaction --no-update
           if [ "${{ matrix.php }}" = "8.2" ]; then composer remove pestphp/pest-plugin-browser --dev --no-interaction --no-update; fi
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.5, 8.4, 8.3]
-        laravel: [13.*, 12.*, 11.*]
+        laravel: [13.*, 12.*]
         filament: [5.*]
         stability: [prefer-stable]
         include:
@@ -30,8 +30,6 @@ jobs:
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
           # Targeted Filament v4 coverage (v5 is covered by the matrix above).
           # Filament 4 and 5 support the same Laravel range, so one v4 job per
           # Laravel line is enough without doubling the matrix. (PHP 8.2 isn't
@@ -41,19 +39,11 @@ jobs:
             testbench: 11.*
             filament: 4.*
             stability: prefer-stable
-          - php: 8.4
+          - php: 8.3
             laravel: 12.*
             testbench: 10.*
             filament: 4.*
             stability: prefer-stable
-          - php: 8.3
-            laravel: 11.*
-            testbench: 9.*
-            filament: 4.*
-            stability: prefer-stable
-        exclude:
-          - laravel: 11.*
-            php: 8.5
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.stability }}
     steps:
       - name: Checkout Code
@@ -79,7 +69,6 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-          composer config policy.advisories.block false
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:${{ matrix.filament }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,9 @@ jobs:
           - laravel: 11.*
             testbench: 9.*
           # Targeted Filament v4 coverage (v5 is covered by the matrix above).
-          # Filament 4 and 5 support the same Laravel/PHP range, so one job per
-          # Laravel line is enough without doubling the matrix.
+          # Filament 4 and 5 support the same Laravel range, so one v4 job per
+          # Laravel line is enough without doubling the matrix. (PHP 8.2 isn't
+          # tested here since Filament 5 requires PHP 8.3+ via Livewire 4.)
           - php: 8.4
             laravel: 13.*
             testbench: 11.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         php: [8.5, 8.4, 8.3]
         laravel: [13.*, 12.*, 11.*]
+        filament: [5.*]
         stability: [prefer-stable]
         include:
           - laravel: 13.*
@@ -31,10 +32,28 @@ jobs:
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
+          # Targeted Filament v4 coverage (v5 is covered by the matrix above).
+          # Filament 4 and 5 support the same Laravel/PHP range, so one job per
+          # Laravel line is enough without doubling the matrix.
+          - php: 8.4
+            laravel: 13.*
+            testbench: 11.*
+            filament: 4.*
+            stability: prefer-stable
+          - php: 8.4
+            laravel: 12.*
+            testbench: 10.*
+            filament: 4.*
+            stability: prefer-stable
+          - php: 8.3
+            laravel: 11.*
+            testbench: 9.*
+            filament: 4.*
+            stability: prefer-stable
         exclude:
           - laravel: 11.*
             php: 8.5
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.stability }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -60,7 +79,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
           composer config policy.advisories.block false
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:${{ matrix.filament }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+          composer config policy.advisories.block false
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 

--- a/src/BotlyPlugin.php
+++ b/src/BotlyPlugin.php
@@ -157,7 +157,10 @@ class BotlyPlugin implements Plugin
 
     public function getPersistentRules(): array
     {
-        return $this->persistentRules ?? config('botly.persistent_rules', []);
+        return [
+            ...config('botly.persistent_rules', []),
+            ...($this->persistentRules ?? []),
+        ];
     }
 
     /**

--- a/tests/src/BotlyPluginTest.php
+++ b/tests/src/BotlyPluginTest.php
@@ -54,6 +54,21 @@ it('returns persistent rules set directly on the plugin', function (): void {
     expect(BotlyPlugin::make()->persistentRules($rules)->getPersistentRules())->toBe($rules);
 });
 
+it('merges persistent rules from config and the plugin', function (): void {
+    config()->set('botly.persistent_rules', [
+        ['user_agent' => '*', 'directive' => 'Disallow', 'path' => '/admin'],
+    ]);
+
+    $rules = [
+        ['user_agent' => '*', 'directive' => 'Disallow', 'path' => '/secret'],
+    ];
+
+    expect(BotlyPlugin::make()->persistentRules($rules)->getPersistentRules())->toBe([
+        ['user_agent' => '*', 'directive' => 'Disallow', 'path' => '/admin'],
+        ['user_agent' => '*', 'directive' => 'Disallow', 'path' => '/secret'],
+    ]);
+});
+
 it('returns a non-empty list of ai crawlers', function (): void {
     $crawlers = BotlyPlugin::make()->getAICrawlers();
 


### PR DESCRIPTION
## Summary

Fixes #5. Persistent rules defined in `config('botly.persistent_rules')` were silently dropped whenever rules were also set via `BotlyPlugin::make()->persistentRules(...)`.

The cause was a null-coalesce in `getPersistentRules()` that short-circuited the config lookup as soon as the plugin had rules set:

```php
return $this->persistentRules ?? config('botly.persistent_rules', []);
```

Both sources are now merged, with config rules first followed by plugin rules.

## Testing

- Added a test covering the combined config + plugin case.
- `composer test` passes (Rector, Pint, PHPStan level 5, 37 Pest tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)