### PR TITLE
Normalize CI workflows to the fleet standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.composer/cache/files
           key: composer-cs-${{ hashFiles('composer.json') }}
@@ -27,7 +27,7 @@ jobs:
             composer-cs-
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.3
 
@@ -41,7 +41,7 @@ jobs:
         run: composer lint
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "Format Code"
           commit_user_name: 'GitHub Actions'

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -61,10 +61,10 @@ jobs:
             dependency-version: prefer-stable
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.dependency-version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.composer/cache/files
           key: composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
@@ -73,7 +73,7 @@ jobs:
             composer-${{ matrix.php }}-
 
       - name: Cache PHPStan result
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/phpstan
           key: phpstan-${{ matrix.php }}-${{ matrix.laravel }}-${{ github.sha }}
@@ -81,7 +81,7 @@ jobs:
             phpstan-${{ matrix.php }}-${{ matrix.laravel }}-
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, pdo, pdo_sqlite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,60 +17,46 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        php: [8.5, 8.4, 8.3]
+        os: [ubuntu-latest]
+        php: [8.4, 8.3]
         laravel: [13.*, 12.*]
-        filament: [5.*]
         stability: [prefer-stable]
         include:
           - laravel: 13.*
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          # Targeted Filament v4 coverage (v5 is covered by the matrix above).
-          # Filament 4 and 5 support the same Laravel range, so one v4 job per
-          # Laravel line is enough without doubling the matrix. (PHP 8.2 isn't
-          # tested here since Filament 5 requires PHP 8.3+ via Livewire 4.)
-          - php: 8.4
-            laravel: 13.*
-            testbench: 11.*
-            filament: 4.*
-            stability: prefer-stable
-          - php: 8.3
-            laravel: 12.*
-            testbench: 10.*
-            filament: 4.*
-            stability: prefer-stable
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - F${{ matrix.filament }} - ${{ matrix.stability }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Cache Composer dependencies
-        uses: actions/cache@v5
+      - name: Cache Dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.composer/cache/files
-          key: composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
-          restore-keys: |
-            composer-${{ matrix.php }}-${{ matrix.laravel }}-
-            composer-${{ matrix.php }}-
+          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, pdo, pdo_sqlite, pdo_mysql, pdo_pgsql
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo_sqlite
           coverage: none
 
       - name: Install Dependencies
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "filament/filament:${{ matrix.filament }}" --no-interaction --no-update
+
+      - name: Install Dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: ./vendor/bin/pest --parallel
+        run: vendor/bin/pest --parallel


### PR DESCRIPTION
CI-only. Makes this package's workflows match the normalized plugins, ahead of the shared-CI migration.

## Changes
- `tests.yml` → standard matrix (PHP 8.3/8.4 × Laravel 12/13, prefer-stable), trimmed extensions (keep `pcntl` for `pest --parallel`).
- SHA-pin all actions to their latest release.
- Add a 7-day dependabot cooldown.
- Drops the bespoke Filament 4/5 matrix dimension and PHP 8.5 jobs to match the fleet (F5-only via prefer-stable), same call as gravatar.

No composer/README changes — already `^4.0|^5.0`. No release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)