### PR TITLE
docs: add docs/ for the documentation hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 build
 composer.lock
 coverage
-docs
 node_modules
 phpunit.xml
 phpstan.neon

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,115 @@
+---
+title: Configuration
+description: Set default values, define rules that cannot be edited, and customize Botly's page and navigation entry.
+---
+
+# Configuration
+
+Botly is configured in two places: the published config file, for values that live in your repository, and fluent methods on the plugin, for how the page appears in your panel.
+
+## The config file
+
+Publish the config file with:
+
+```bash
+php artisan vendor:publish --tag="botly-config"
+```
+
+It contains two keys:
+
+```php
+return [
+    'defaults' => [
+        'rules' => [],
+        'sitemaps' => [],
+        'ai_crawlers' => [],
+    ],
+    'persistent_rules' => [],
+];
+```
+
+### Defaults
+
+The `defaults` array seeds the output before anything has been saved in the panel. It is used only while no Botly record exists in the database — as soon as the Robots Manager page is saved for the first time, the stored values take over and `defaults` is no longer consulted.
+
+Use it to give a fresh install sensible output, not as a way to enforce rules. For rules that must always be present, use persistent rules instead.
+
+### Persistent rules
+
+Persistent rules are always included in the output and cannot be edited or deleted from the admin UI. They appear in the rules list on the page with their fields disabled and no delete action.
+
+Define them in the config file:
+
+```php
+// config/botly.php
+'persistent_rules' => [
+    [
+        'user_agent' => '*',
+        'directive' => 'disallow',
+        'path' => '/admin',
+    ],
+],
+```
+
+Or fluently on the plugin:
+
+```php
+BotlyPlugin::make()
+    ->persistentRules([
+        [
+            'user_agent' => '*',
+            'directive' => 'disallow',
+            'path' => '/admin',
+        ],
+    ]),
+```
+
+Both sources are used — rules from the config file come first, followed by rules passed to `persistentRules()`. Each rule is an array with three keys:
+
+| Key | Values |
+|---|---|
+| `user_agent` | Any string, for example `*` or `Googlebot` |
+| `directive` | `allow`, `disallow`, `crawl-delay` or `clean-param` |
+| `path` | The path the directive applies to, for example `/admin` |
+
+Persistent rules are emitted before the rules stored in the database.
+
+## Authorization
+
+By default, any user who can reach your panel can open the Botly page. Restrict it by passing a boolean or a closure to `authorize()`:
+
+```php
+// Always deny access
+BotlyPlugin::make()
+    ->authorize(false),
+
+// Conditionally allow access
+BotlyPlugin::make()
+    ->authorize(fn (): bool => auth()->user()->isAdmin()),
+```
+
+Access is granted only when the value resolves to exactly `true`.
+
+## Navigation
+
+Customize how the page appears in your panel's navigation:
+
+```php
+BotlyPlugin::make()
+    ->navigationIcon('heroicon-o-document-text')
+    ->navigationGroup('Settings')
+    ->navigationLabel('Robots.txt')
+    ->navigationSort(3),
+```
+
+If you do not set an icon, Botly uses its own built-in robot icon. The navigation label defaults to **Robots Manager**.
+
+## Page title and slug
+
+```php
+BotlyPlugin::make()
+    ->title('Robots Manager')
+    ->slug('robots-manager'),
+```
+
+The title defaults to **Manage robots.txt** and the slug defaults to `botly`, so the page lives at `/{panel-path}/botly` unless you change it.

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -1,0 +1,9 @@
+version: 1
+
+title: Botly
+
+navigation:
+  - index
+  - installation
+  - usage
+  - configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+---
+title: Botly
+description: Manage your site's robots.txt file from the Filament admin panel, stored in the database and served dynamically.
+---
+
+# Botly
+
+Botly is a Filament plugin for managing your site's `robots.txt` file from your admin panel. Rules, sitemaps and AI crawler blocks are stored in the database and served dynamically, so you do not need to keep a static file in your repository or redeploy to change what crawlers are told.
+
+It is for sites where the people who decide crawler policy are not the people who deploy the code — a marketing team that needs to block a bot today, or a site where `robots.txt` changes often enough that editing a file in version control is friction.
+
+## How it works
+
+Botly registers a **Robots Manager** page in your panel and a route that answers `/robots.txt`.
+
+When a crawler requests `/robots.txt`, Botly reads the current configuration from the database, merges in any persistent rules you have defined in code, and formats the result as valid `robots.txt` output on the fly. Nothing is written to disk unless you ask for it.
+
+The output is assembled in a fixed order:
+
+1. Rules, grouped by user agent — persistent rules first, then the rules stored in the database.
+2. Blocked AI crawlers, each as a `User-agent` line followed by `Disallow: /`.
+3. Sitemap URLs, as `Sitemap:` lines.
+
+If you would rather serve a static file, the admin page has an **Export Robots.txt** action that writes the current output to `public/robots.txt`.
+
+> [!IMPORTANT]
+> A static `public/robots.txt` file takes precedence over Botly's route, because the web server serves it before the request ever reaches Laravel. If one exists, Botly shows a warning on the admin page with actions to delete or rename it.
+
+## Requirements
+
+Botly requires PHP 8.2 or higher and Filament v4 or v5.
+
+## Where to go next
+
+- [Installation](installation.md) — install the package, run the migration and register the plugin.
+- [Usage](usage.md) — manage rules, sitemaps and AI crawler blocks from the admin page.
+- [Configuration](configuration.md) — set defaults, define rules that cannot be edited, and customize the page.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,68 @@
+---
+title: Installation
+description: Install Botly, run its migration and register the plugin in a Filament panel.
+---
+
+# Installation
+
+## Requirements
+
+Botly requires PHP 8.2 or higher and Filament v4 or v5.
+
+## Install the package
+
+Install Botly via Composer:
+
+```bash
+composer require awcodes/botly
+```
+
+## Run the migration
+
+Botly stores its configuration in a database table, so it needs a migration. The install command publishes the migration and offers to run it for you:
+
+```bash
+php artisan botly:install
+```
+
+If you would rather do it yourself, publish the migration and migrate manually:
+
+```bash
+php artisan vendor:publish --tag="botly-migrations"
+php artisan migrate
+```
+
+## Publish the config file
+
+The config file is optional. Publish it if you want to set default values or define persistent rules in code:
+
+```bash
+php artisan vendor:publish --tag="botly-config"
+```
+
+See [Configuration](configuration.md) for what it contains.
+
+## Register the plugin
+
+Register Botly in your panel provider:
+
+```php
+use Awcodes\Botly\BotlyPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            BotlyPlugin::make(),
+        ]);
+}
+```
+
+That is the whole setup. Botly registers a **Robots Manager** page in your panel and a route that answers `/robots.txt`.
+
+## Check for an existing file
+
+If your project already has a `public/robots.txt`, your web server will serve that file directly and Botly's route will never run. Botly detects this and shows a warning on the admin page with actions to delete the file or rename it to `robots-bak.txt`.
+
+> [!TIP]
+> Visit `/robots.txt` after installing. If you see your old contents rather than what the admin page shows, a static file is still in place.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,61 @@
+---
+title: Usage
+description: Manage crawler rules, sitemaps and AI crawler blocks from the Robots Manager page.
+---
+
+# Usage
+
+Everything Botly serves is managed from the **Robots Manager** page in your panel. The page has three sections — rules, sitemaps and AI crawler blocking — and saves them all together.
+
+## Rules
+
+A rule is a single directive aimed at a single user agent. Each rule has three fields:
+
+| Field | Values |
+|---|---|
+| User-Agent | Any string, for example `*` or `Googlebot` |
+| Directive | `Allow`, `Disallow`, `Crawl-delay` or `Clean-param` |
+| Path | The path the directive applies to, for example `/admin` |
+
+New rules default to a user agent of `*` and a directive of `Disallow`. All three fields are required.
+
+Rules are grouped by user agent in the output, so several rules aimed at the same agent are emitted under a single `User-agent` line:
+
+```text
+User-agent: *
+Disallow: /admin
+Disallow: /private
+
+User-agent: Googlebot
+Allow: /
+```
+
+Rules defined in code as persistent rules also appear in this list, but cannot be edited or removed here. See [Configuration](configuration.md) for how to define them.
+
+## Sitemaps
+
+The sitemaps section takes a list of full sitemap URLs. Each one is emitted as its own `Sitemap:` line at the end of the output:
+
+```text
+Sitemap: https://example.com/sitemap.xml
+```
+
+## Blocking AI crawlers
+
+The **Block AI Crawlers** section is a checkbox list of known AI bots. Checking one adds a `Disallow: /` entry for it:
+
+```text
+User-agent: GPTBot
+Disallow: /
+```
+
+Botly ships with a curated list that includes GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, anthropic-ai, claude-web, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, Bytespider, CCBot and others.
+
+> [!NOTE]
+> Blocking a crawler in `robots.txt` is a request, not an enforcement mechanism. Well-behaved crawlers honour it; nothing stops one that does not.
+
+## Exporting a static file
+
+The **Export Robots.txt** action writes the current output to `public/robots.txt` as a static file.
+
+This is useful if you want to stop serving the file dynamically, or want a snapshot committed to your repository. Be aware of the trade-off: once that file exists, your web server serves it directly and further changes made on the admin page will have no effect until you delete it or export again.


### PR DESCRIPTION
Adds a structured `docs/` directory so this package can be published to the documentation hub.

- Stops `.gitignore` from ignoring `docs`. The package skeleton ignored it, which would have made the whole directory invisible to git silently.
- Adds 4 pages: index, installation, usage, configuration.

Content is derived from the README and verified against the source — directive values against the form's select options, the merge order and defaults behaviour against `ParseDirectivesToText`, and the default title, navigation label and slug against `BotlyPlugin` and the translation file. The README is unchanged.

Docs are version-scoped by branch, so these are the 1.x docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)