### PR TITLE
fix: use a real heroicon in the navigation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ BotlyPlugin::make()
 
 ```php
 BotlyPlugin::make()
-    ->navigationIcon('heroicon-o-robot')
+    ->navigationIcon('heroicon-o-document-text')
     ->navigationGroup('Settings')
-    ->navigationLabel('Robots.txt'),
+    ->navigationLabel('Robots.txt')
+    ->navigationSort(3),
 ```
 
 ### Page


### PR DESCRIPTION
The Navigation example in the README passes an icon that does not exist:

```php
BotlyPlugin::make()
    ->navigationIcon('heroicon-o-robot')
```

There is no robot icon in Heroicons — confirmed against the installed set, which has no `o-robot.svg`. That is precisely why `BotlyPlugin::getNavigationIcon()` falls back to a hand-rolled inline SVG rather than a heroicon. Anyone copying the example gets an icon that cannot be resolved.

Swapped for `heroicon-o-document-text`, which does exist. Also added `navigationSort()` to the example — the method exists on the plugin but the README never mentioned it.

Documentation only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)